### PR TITLE
Adding endpoints for providers and QPU metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,15 @@ The reponse also includes the counts of simulator and quantum computer as well a
 Sample implementations can be found [here](https://github.com/UST-QuAntiL/nisq-analyzer-content/tree/master/example-implementations).
 Please use the raw GitHub URL as `impl-url` value (see [example](https://raw.githubusercontent.com/UST-QuAntiL/nisq-analyzer-content/master/example-implementations/Shor/shor-general-qiskit.py)).
 
+## Get up-to-date data of QPUs
+Get provider information:  
+`GET /qiskit-service/api/v1.0/providers` 
+
+Get up-to-date information about QPUs of IBMQ:  
+`GET /qiskit-service/api/v1.0/providers/f8f0c200-875d-0ff8-0352-1be4666c5829/qpus`   
+For the request, add your Qiskit token as header:  
+`token: <YOUR-IBMQ-TOKEN>` 
+
 ## Haftungsausschluss
 
 Dies ist ein Forschungsprototyp.

--- a/app/ibmq_handler.py
+++ b/app/ibmq_handler.py
@@ -18,8 +18,9 @@
 # ******************************************************************************
 from time import sleep
 
-from qiskit import IBMQ, QiskitError, QuantumRegister, execute
+from qiskit import QiskitError, QuantumRegister, execute
 from qiskit.ignis.mitigation import CompleteMeasFitter, complete_meas_cal
+from qiskit.providers.ibmq import IBMQ
 from qiskit.providers.jobstatus import JOB_FINAL_STATES
 from qiskit.providers.exceptions import JobError, JobTimeoutError
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
@@ -29,9 +30,7 @@ from qiskit.providers.ibmq.api.exceptions import RequestsApiError
 def get_qpu(token, qpu_name):
     """Load account from token. Get backend."""
     try:
-        IBMQ.save_account(token, overwrite=True)
-        IBMQ.load_account()
-        provider = IBMQ.get_provider(group='open')
+        provider = IBMQ.enable_account(token, group="open")
         backend = provider.get_backend(qpu_name)
         return backend
     except (QiskitBackendNotFoundError, RequestsApiError):

--- a/app/ibmq_handler.py
+++ b/app/ibmq_handler.py
@@ -30,6 +30,11 @@ from qiskit.providers.ibmq.api.exceptions import RequestsApiError
 def get_qpu(token, qpu_name):
     """Load account from token. Get backend."""
     try:
+        try:
+            IBMQ.disable_account()
+        except:
+            pass
+
         provider = IBMQ.enable_account(token, group="open")
         backend = provider.get_backend(qpu_name)
         return backend

--- a/app/qpu_metrics.py
+++ b/app/qpu_metrics.py
@@ -1,5 +1,7 @@
+import time
 from datetime import datetime
 from hashlib import sha256
+from multiprocessing import Pool
 from typing import List
 from uuid import UUID
 
@@ -173,10 +175,9 @@ def get_all_qpus_and_metrics_as_json_str(token: str):
 
 	account_provider = IBMQ.enable_account(token)
 	backends = account_provider.backends()
-	qpu_dtoes = []
 
-	for backend in backends:
-		qpu_dtoes.append(backend_to_dto(backend))
+	with Pool(16) as p:
+		qpu_dtoes = p.map(backend_to_dto, backends)
 
 	result = QpuListEmbedded(QpuList(qpu_dtoes))
 

--- a/app/qpu_metrics.py
+++ b/app/qpu_metrics.py
@@ -102,10 +102,14 @@ def backend_to_dto(backend: IBMQBackend) -> Qpu:
 		sum_t2 = 0
 		sum_readout_error = 0
 
-		for q in range(number_of_qubits):
-			sum_t1 += properties.t1(q)
-			sum_t2 += properties.t2(q)
-			sum_readout_error += properties.readout_error(q)
+		for qubit in properties.qubits:
+			for property in qubit:
+				if property.name == "T1":
+					sum_t1 += property.value
+				if property.name == "T2":
+					sum_t2 += property.value
+				if property.name == "readout_error":
+					sum_readout_error += property.value
 
 		avg_t1 = sum_t1 / number_of_qubits
 		avg_t2 = sum_t2 / number_of_qubits
@@ -124,9 +128,9 @@ def backend_to_dto(backend: IBMQBackend) -> Qpu:
 				for param in gate.parameters:
 					if param.name == "gate_error":
 						sum_single_qubit_gate_error += param.value
-						max_gate_time = max(max_gate_time, param.value)
 					if param.name == "gate_length":
 						sum_single_qubit_gate_time += param.value
+						max_gate_time = max(max_gate_time, param.value)
 				single_qubit_gate_cnt += 1
 			if len(gate.qubits) == 2:
 				for param in gate.parameters:

--- a/app/qpu_metrics.py
+++ b/app/qpu_metrics.py
@@ -161,8 +161,13 @@ def backend_to_dto(backend: IBMQBackend) -> Qpu:
 			max_gate_time=max_gate_time, simulator=False)
 
 
-def get_all_qpus_and_metrics_as_json_str():
-	account_provider = IBMQ.load_account()
+def get_all_qpus_and_metrics_as_json_str(token: str):
+	try:
+		IBMQ.disable_account()
+	except:
+		pass
+
+	account_provider = IBMQ.enable_account(token)
 	backends = account_provider.backends()
 	qpu_dtoes = []
 

--- a/app/qpu_metrics.py
+++ b/app/qpu_metrics.py
@@ -1,0 +1,174 @@
+from datetime import datetime
+from hashlib import sha256
+from typing import List
+from uuid import UUID
+
+from qiskit.providers.ibmq import IBMQ, IBMQBackend
+from marshmallow import Schema, fields
+from qiskit.providers.ibmq.ibmqbackend import IBMQSimulator
+
+
+class Qpu:
+	def __init__(
+			self, id: str, name: str, version: str, last_updated: str, last_calibrated: str, max_shots: int, queue_size: int,
+			number_of_qubits: int, avg_t1_time: float, avg_t2_time: float, avg_readout_error: float,
+			avg_single_qubit_gate_error: float, avg_multi_qubit_gate_error: float, avg_single_qubit_gate_time: float,
+			avg_multi_qubit_gate_time: float, max_gate_time: float, simulator: bool):
+		self.id = id
+		self.name = name
+		self.version = version
+		self.last_updated = last_updated
+		self.last_calibrated = last_calibrated
+		self.max_shots = max_shots
+		self.queue_size = queue_size
+		self.number_of_qubits = number_of_qubits
+		self.avg_t1_time = avg_t1_time
+		self.avg_t2_time = avg_t2_time
+		self.avg_readout_error = avg_readout_error
+		self.avg_single_qubit_gate_error = avg_single_qubit_gate_error
+		self.avg_multi_qubit_gate_error = avg_multi_qubit_gate_error
+		self.avg_single_qubit_gate_time = avg_single_qubit_gate_time
+		self.avg_multi_qubit_gate_time = avg_multi_qubit_gate_time
+		self.max_gate_time = max_gate_time
+		self.simulator = simulator
+
+
+class QpuSchema(Schema):
+	id = fields.UUID()
+	name = fields.Str()
+	version = fields.Str()
+	last_updated = fields.Str(data_key="lastUpdated")
+	last_calibrated = fields.Str(data_key="lastCalibrated")
+	max_shots = fields.Int(data_key="maxShots")
+	queue_size = fields.Int(data_key="queueSize")
+	number_of_qubits = fields.Int(data_key="numberOfQubits")
+	avg_t1_time = fields.Float(data_key="avgT1Time")
+	avg_t2_time = fields.Float(data_key="avgT2Time")
+	avg_readout_error = fields.Float(data_key="avgReadoutError")
+	avg_single_qubit_gate_error = fields.Float(data_key="avgSingleQubitGateError")
+	avg_multi_qubit_gate_error = fields.Float(data_key="avgMultiQubitGateError")
+	avg_single_qubit_gate_time = fields.Float(data_key="avgSingleQubitGateTime")
+	avg_multi_qubit_gate_time = fields.Float(data_key="avgMultiQubitGateTime")
+	max_gate_time = fields.Float(data_key="maxGateTime")
+	simulator = fields.Bool()
+
+
+class QpuList:
+	def __init__(self, qpus: List[Qpu]):
+		self.qpu_dtoes = qpus
+
+
+class QpuListSchema(Schema):
+	qpu_dtoes = fields.List(fields.Nested(QpuSchema), data_key="qpuDtoes")
+
+
+class QpuListEmbedded:
+	def __init__(self, qpu_list: QpuList):
+		self.embedded = qpu_list
+
+
+class QpuListEmbeddedSchema(Schema):
+	embedded = fields.Nested(QpuListSchema, data_key="_embedded")
+
+
+def generate_deterministic_uuid(namespace: str, name: str) -> UUID:
+	digest = sha256(sha256(bytes(namespace, "utf-8")).digest() + sha256(bytes(name, "utf-8")).digest()).digest()
+
+	return UUID(bytes=digest[0:16])
+
+
+def backend_to_dto(backend: IBMQBackend) -> Qpu:
+	properties = backend.properties()
+	status = backend.status()
+
+	backend_name = status.backend_name
+	backend_version = status.backend_version
+	queue_size = status.pending_jobs
+	max_shots = backend.configuration().max_shots
+	number_of_qubits = backend.configuration().n_qubits
+
+	qpu_id = generate_deterministic_uuid("ibmq.qpu", backend_name)
+	last_updated_utc = datetime.utcnow().isoformat()
+
+	if isinstance(backend, IBMQSimulator):
+		return Qpu(
+			id=str(qpu_id), name=backend_name, version=backend_version, last_updated=last_updated_utc, last_calibrated="",
+			max_shots=max_shots, queue_size=queue_size, number_of_qubits=number_of_qubits, avg_t1_time=0,
+			avg_t2_time=0, avg_readout_error=0, avg_single_qubit_gate_error=0, avg_multi_qubit_gate_error=0,
+			avg_single_qubit_gate_time=0, avg_multi_qubit_gate_time=0, max_gate_time=0, simulator=True)
+	else:
+		number_of_qubits = len(properties.qubits)
+		sum_t1 = 0
+		sum_t2 = 0
+		sum_readout_error = 0
+
+		for q in range(number_of_qubits):
+			sum_t1 += properties.t1(q)
+			sum_t2 += properties.t2(q)
+			sum_readout_error += properties.readout_error(q)
+
+		avg_t1 = sum_t1 / number_of_qubits
+		avg_t2 = sum_t2 / number_of_qubits
+		avg_readout_error = sum_readout_error / number_of_qubits
+
+		sum_single_qubit_gate_error = 0
+		sum_single_qubit_gate_time = 0
+		single_qubit_gate_cnt = 0
+		sum_multi_qubit_gate_error = 0
+		sum_multi_qubit_gate_time = 0
+		multi_qubit_gate_cnt = 0
+		max_gate_time = 0
+
+		for gate in properties.gates:
+			if len(gate.qubits) == 1:
+				for param in gate.parameters:
+					if param.name == "gate_error":
+						sum_single_qubit_gate_error += param.value
+						max_gate_time = max(max_gate_time, param.value)
+					if param.name == "gate_length":
+						sum_single_qubit_gate_time += param.value
+				single_qubit_gate_cnt += 1
+			if len(gate.qubits) == 2:
+				for param in gate.parameters:
+					if param.name == "gate_error":
+						sum_multi_qubit_gate_error += param.value
+						max_gate_time = max(max_gate_time, param.value)
+					if param.name == "gate_length":
+						sum_multi_qubit_gate_time += param.value
+				multi_qubit_gate_cnt += 1
+
+		avg_single_qubit_gate_error = sum_single_qubit_gate_error / single_qubit_gate_cnt
+		avg_single_qubit_gate_time = sum_single_qubit_gate_time / single_qubit_gate_cnt
+		avg_multi_qubit_gate_error = 0
+
+		if multi_qubit_gate_cnt != 0:
+			avg_multi_qubit_gate_error = sum_multi_qubit_gate_error / multi_qubit_gate_cnt
+
+		avg_multi_qubit_gate_time = 0
+
+		if multi_qubit_gate_cnt != 0:
+			avg_multi_qubit_gate_time = sum_multi_qubit_gate_time / multi_qubit_gate_cnt
+
+		last_calibrated_with_timezone: datetime = properties.last_update_date
+		last_calibrated_utc = datetime.utcfromtimestamp(last_calibrated_with_timezone.timestamp()).isoformat()
+
+		return Qpu(
+			id=str(qpu_id), name=backend_name, version=backend_version, last_updated=last_updated_utc,
+			last_calibrated=last_calibrated_utc, max_shots=max_shots, queue_size=queue_size, number_of_qubits=number_of_qubits,
+			avg_t1_time=avg_t1, avg_t2_time=avg_t2, avg_readout_error=avg_readout_error,
+			avg_single_qubit_gate_error=avg_single_qubit_gate_error, avg_multi_qubit_gate_error=avg_multi_qubit_gate_error,
+			avg_single_qubit_gate_time=avg_single_qubit_gate_time, avg_multi_qubit_gate_time=avg_multi_qubit_gate_time,
+			max_gate_time=max_gate_time, simulator=False)
+
+
+def get_all_qpus_and_metrics_as_json_str():
+	account_provider = IBMQ.load_account()
+	backends = account_provider.backends()
+	qpu_dtoes = []
+
+	for backend in backends:
+		qpu_dtoes.append(backend_to_dto(backend))
+
+	result = QpuListEmbedded(QpuList(qpu_dtoes))
+
+	return QpuListEmbeddedSchema().dump(result)

--- a/app/routes.py
+++ b/app/routes.py
@@ -318,18 +318,14 @@ def get_providers():
 def get_qpus_and_metrics_of_provider(provider_id: str):
     """Return qpus and metrics of the specified provider."""
 
-    if request.mimetype != "application/json":
-        return jsonify({"message": "Error: request was not of mimetype application/json"}), 400
-
-    if not request.json:
-        return jsonify({"message": "Error: JSON missing in request"}), 400
-
-    if not request.json["token"]:
+    if 'token' not in request.headers:
         return jsonify({"message": "Error: token missing in request"}), 401
+
+    token = request.headers.get('token')
 
     if provider_id == str(generate_deterministic_uuid("ibmq", "provider")):
         try:
-            return get_all_qpus_and_metrics_as_json_str(request.json["token"]), 200
+            return get_all_qpus_and_metrics_as_json_str(token), 200
         except IBMQAccountError:
             return jsonify({"message": "the provided token is wrong"}), 401
     else:

--- a/app/routes.py
+++ b/app/routes.py
@@ -19,6 +19,7 @@
 
 from app import app, benchmarking, ibmq_handler, implementation_handler, db, parameters, circuit_analysis, analysis
 from app.benchmark_model import Benchmark
+from app.qpu_metrics import generate_deterministic_uuid, get_all_qpus_and_metrics_as_json_str
 from app.result_model import Result
 from flask import jsonify, abort, request
 from qiskit import transpile
@@ -294,6 +295,31 @@ def get_benchmark(benchmark_id):
                                                       'complete': benchmark_real.complete}]}), 200
     else:
         abort(404)
+
+
+@app.route('/qiskit-service/api/v1.0/providers', methods=['GET'])
+def get_providers():
+    """Return available providers."""
+    return jsonify({
+        "_embedded": {
+            "providerDtoes": [
+                {
+                    "id": str(generate_deterministic_uuid("ibmq", "provider")),
+                    "name": "ibmq",
+                    "offeringURL": "https://quantum-computing.ibm.com/",
+                }
+            ]
+        }
+    }), 200
+
+
+@app.route('/qiskit-service/api/v1.0/providers/<provider_id>/qpus', methods=['GET'])
+def get_qpus_and_metrics_of_provider(provider_id: str):
+    """Return qpus and metrics of the specified provider."""
+    if provider_id == str(generate_deterministic_uuid("ibmq", "provider")):
+        return get_all_qpus_and_metrics_as_json_str(), 200
+    else:
+        return jsonify({"message": "Error: unknown provider ID."}), 400
 
 
 @app.route('/qiskit-service/api/v1.0/analysis', methods=['GET'])

--- a/requirements-unfrozen.txt
+++ b/requirements-unfrozen.txt
@@ -10,3 +10,4 @@ requests
 rq
 SQLAlchemy
 gunicorn
+marshmallow

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ dlx==1.0.4
 docplex==2.15.194
 fastdtw==0.3.4
 fastjsonschema==2.15.3
-Flask==2.1.1
+Flask~=2.1.2
 Flask-Migrate==3.1.0
 Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.5.1
@@ -30,12 +30,13 @@ jsonschema==4.4.0
 lxml==4.8.0
 Mako==1.2.0
 MarkupSafe==2.1.1
+marshmallow~=3.15.0
 more-itertools==8.12.0
 mpmath==1.2.1
 multitasking==0.0.10
 nest-asyncio==1.5.5
 ntlm-auth==1.5.0
-numpy==1.20.1
+numpy~=1.22.3
 packaging==21.3
 pandas==1.2.3
 pbr==5.8.1
@@ -54,7 +55,7 @@ qiskit-ibmq-provider==0.18.3
 qiskit-ignis==0.7.0
 qiskit-terra==0.20.0
 Quandl==3.6.0
-redis==4.2.2
+redis~=4.3.1
 requests==2.27.1
 requests-ntlm==1.1.0
 retworkx==0.11.0
@@ -62,7 +63,7 @@ rq==1.10.1
 scikit-learn==0.24.1
 scipy==1.6.1
 six==1.16.0
-SQLAlchemy==1.4.34
+SQLAlchemy~=1.4.36
 stevedore==3.5.0
 symengine==0.9.2
 sympy==1.7.1


### PR DESCRIPTION
This PR adds endpoints for providers and QPU metrics that are equivalent to those in [QProv](https://github.com/UST-QuAntiL/qprov.git), but only for IBMQ. The differences are that the responses of these endpoints don't contain the "_links" field and that the request to get the QPU metrics needs to contain an IBMQ token like this: `{"token": "<IBMQ token>"}`. The endpoints are available at the following URLs when hosted locally:
http://localhost:5013/qiskit-service/api/v1.0/providers
http://localhost:5013/qiskit-service/api/v1.0/providers/f8f0c200-875d-0ff8-0352-1be4666c5829/qpus
